### PR TITLE
Toggle reverse geocoding

### DIFF
--- a/bulkNominatim.py
+++ b/bulkNominatim.py
@@ -77,8 +77,12 @@ class BulkNominatim(object):
         self.reverseGeocodeTool.unload()
     
     def setReverseGeocodeTool(self):
-        self.reverseGeocodeAction.setChecked(True)
-        self.canvas.setMapTool(self.reverseGeocodeTool)
+        if self.reverseGeocodeAction.isChecked():
+            self.reverseGeocodeAction.setChecked(False)
+            self.canvas.unsetMapTool(self.reverseGeocodeTool)
+        else:
+            self.reverseGeocodeAction.setChecked(True)
+            self.canvas.setMapTool(self.reverseGeocodeTool)
         
     def nominatimTool(self):
         """Display the dialog window."""


### PR DESCRIPTION
Toggle on/off the reverse geocoding from the toolbar or from the menu.

This PR is an upstream push as a part of the work from LocationIQ.